### PR TITLE
feat: add creative block world demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # static_page
+
+Mini Minecraft-style creative demo built with Three.js.
+
+Features:
+- Procedural terrain generated with Simplex noise
+- Block placement and destruction in creative mode
+- Player movement with gravity and simple collision
+- Mobile controls via on-screen joystick and buttons
+
+Open `index.html` in a browser to play.

--- a/index.html
+++ b/index.html
@@ -1,87 +1,256 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-<title>F1 더 무비 밈</title>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<style>
-body {
-background-color: #000;
-color: #fff;
-font-family: 'Malgun Gothic', sans-serif;
-display: flex;
-justify-content: center;
-align-items: center;
-min-height: 100vh;
-margin: 0;
-overflow: hidden;
-}
-.meme-container {
-width: 90%;
-max-width: 800px;
-padding: 20px;
-border: 2px solid #e10600;
-border-radius: 10px;
-box-shadow: 0 0 20px #e10600;
-text-align: center;
-opacity: 0;
-transform: translateY(20px);
-animation: fadeIn 1.5s ease-out forwards;
-}
-@keyframes fadeIn {
-to {
-opacity: 1;
-transform: translateY(0);
-}
-}
-.meme-container h2, .meme-container p {
-opacity: 0;
-animation: textFadeIn 1s ease-out forwards;
-}
-.meme-container h2 {
-font-size: 1.8em;
-color: #e10600;
-margin-bottom: 20px;
-animation-delay: 1s;
-}
-.meme-container p {
-font-size: 1.1em;
-line-height: 1.6;
-margin-bottom: 15px;
-animation-delay: 1.5s;
-}
-.meme-container p:nth-of-type(2) {
-animation-delay: 2s;
-}
-.meme-container p:nth-of-type(3) {
-animation-delay: 2.5s;
-}
-.meme-container p:nth-of-type(4) {
-animation-delay: 3s;
-}
-@keyframes textFadeIn {
-to {
-opacity: 1;
-}
-}
-/* 모바일 환경 반응형 디자인 */
-@media (max-width: 600px) {
-.meme-container h2 {
-font-size: 1.5em;
-}
-.meme-container p {
-font-size: 1em;
-}
-}
-</style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mini Minecraft Creative</title>
+  <style>
+    body { margin: 0; overflow: hidden; }
+    canvas { display: block; }
+    #joystick {
+      position: fixed;
+      left: 20px;
+      bottom: 20px;
+      width: 80px;
+      height: 80px;
+      background: rgba(0,0,0,0.3);
+      border-radius: 50%;
+      touch-action: none;
+    }
+    #joystick-handle {
+      position: absolute;
+      left: 30px;
+      top: 30px;
+      width: 20px;
+      height: 20px;
+      background: #fff;
+      border-radius: 50%;
+      pointer-events: none;
+    }
+    #breakBtn, #placeBtn {
+      position: fixed;
+      right: 20px;
+      width: 60px;
+      height: 60px;
+      border-radius: 30px;
+      background: rgba(0,0,0,0.4);
+      color: #fff;
+      border: none;
+      font-size: 12px;
+      touch-action: manipulation;
+    }
+    #breakBtn { bottom: 20px; }
+    #placeBtn { bottom: 90px; }
+    #crosshair {
+      position: fixed;
+      left: 50%;
+      top: 50%;
+      width: 2px;
+      height: 2px;
+      margin-left: -1px;
+      margin-top: -1px;
+      background: #fff;
+      pointer-events: none;
+    }
+  </style>
 </head>
 <body>
-<div class="meme-container">
-<h2>미안하다 이거 보여주려고 어그로 끌었다..</h2>
-<p>F1 더 무비 레이싱 수준 ㄹㅇ실화냐? 진짜 세계관 최강 드라이버들의 레이스다.. 그 한물간 줄 알았던 소니 헤이스가 맞나? 진짜 F1은 전설이다..</p>
-<p>진짜 옛날에 브래드 피트 영화 맨날 봤는데 은퇴했다 복귀한 베테랑 드라이버 소니 헤이스 보니까 진짜 내가 다 감격스럽고, 엔진 소리부터 명장면까지 가슴 울리는 장면들이 뇌리에 스치면서 가슴이 웅장해진다.. 그리고 마지막 랩에서 조슈아 피어스랑 나란히 달리는 거대한 감동을 갑자기 최첨단 카메라 워크로 보여주곤 개간지나게 "내가 아직 살아있다"는 걸 증명하는 장면은 진짜 F1 처음부터 본 사람이면 안 울 수가 없더라.</p>
-<p>진짜 너무 감격스럽고, F1 입문한 지 얼마 안 됐는데 미안하다.. 지금 N차 관람 중인데 진짜 젊은 드라이버들 사이에서 관록 보여주는 거 보니까 내가 다 뭔가 알 수 없는 희열이라 해야 되나 그런 감정이 이상하게 얽혀있다.. 하비에르 바르뎀은 말이 더 멋있어진 것 같다 좋은 구단주고.. 그리고 이 영화 왜 욕하냐 CGV 에그지수 99%인데.</p>
-<p>그리고 인터넷에 쳐봤는데 이거 ㄹㅇㄹㅇ 진짜 팩트냐?? 실제 F1 드라이버들이랑 같이 달렸다는 게 사실임?? 그리고 루이스 해밀턴이 제작 참여해서 고증했다는 거 보고 개충격 먹어가지고 와 소리 저절로 나오더라;; 진짜 저건 개오지는데.. 저게 ㄹㅇ이면 진짜 꼭 봐야 돼 진짜 실제 서킷을 달리는 거 아니야.. 와 진짜 소니 헤이스가 저렇게 달리다니 진짜 눈물 나려고 했다.. 그래서 계속 N차 관람하는 중인데 저거 ㄹㅇ이냐..? 하.. ㅆㅂ 소니 헤이스 보고 싶다.. 진짜 언제 이렇게 다시 최강이 되었을까 옛날 생각나고 내 젊은 시절 생각나고 뭔가 슬프기도 하고 좋기도 하고 감격도 하고 여러 가지 감정이 복잡하네.. 아무튼 F1 더 무비는 진짜 스포츠 영화 중 최고 명작임..</p>
-</div>
+  <div id="joystick"><div id="joystick-handle"></div></div>
+  <button id="breakBtn">Break</button>
+  <button id="placeBtn">Place</button>
+  <div id="crosshair"></div>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.161.0/build/three.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.161.0/examples/js/controls/PointerLockControls.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/simplex-noise@4.0.1/simplex-noise.js"></script>
+  <script>
+    // ===== 기본 설정 =====
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x87ceeb);
+
+    const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+    camera.position.set(0, 20, 0);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    document.body.appendChild(renderer.domElement);
+
+    // ===== 조명 =====
+    const light = new THREE.DirectionalLight(0xffffff, 1);
+    light.position.set(5, 10, 5);
+    scene.add(light);
+    scene.add(new THREE.AmbientLight(0xffffff, 0.5));
+
+    // ===== 컨트롤 =====
+    const controls = new THREE.PointerLockControls(camera, renderer.domElement);
+    const player = controls.getObject();
+    scene.add(player);
+    document.body.addEventListener('click', () => controls.lock());
+
+    const move = { forward: 0, backward: 0, left: 0, right: 0 };
+    document.addEventListener('keydown', e => {
+      switch(e.code){
+        case 'KeyW': move.forward = 1; break;
+        case 'KeyS': move.backward = 1; break;
+        case 'KeyA': move.left = 1; break;
+        case 'KeyD': move.right = 1; break;
+        case 'Space': if(canJump) velocity.y = 5; canJump = false; break;
+      }
+    });
+    document.addEventListener('keyup', e => {
+      switch(e.code){
+        case 'KeyW': move.forward = 0; break;
+        case 'KeyS': move.backward = 0; break;
+        case 'KeyA': move.left = 0; break;
+        case 'KeyD': move.right = 0; break;
+      }
+    });
+
+    // ===== 모바일용 가상 조이스틱 =====
+    const joystick = document.getElementById('joystick');
+    const handle = document.getElementById('joystick-handle');
+    let touchId = null;
+    let joy = { x: 0, y: 0 };
+    const MAX_DIST = 30;
+
+    joystick.addEventListener('touchstart', e => {
+      if (touchId === null) {
+        touchId = e.changedTouches[0].identifier;
+        handle.style.left = '30px';
+        handle.style.top = '30px';
+      }
+    });
+
+    joystick.addEventListener('touchmove', e => {
+      for (let t of e.changedTouches) {
+        if (t.identifier === touchId) {
+          const rect = joystick.getBoundingClientRect();
+          const x = t.clientX - rect.left - rect.width / 2;
+          const y = t.clientY - rect.top - rect.height / 2;
+          const dist = Math.min(Math.sqrt(x*x + y*y), MAX_DIST);
+          const angle = Math.atan2(y, x);
+          joy.x = (dist / MAX_DIST) * Math.cos(angle);
+          joy.y = (dist / MAX_DIST) * Math.sin(angle);
+          handle.style.left = 30 + joy.x * MAX_DIST + 'px';
+          handle.style.top = 30 + joy.y * MAX_DIST + 'px';
+        }
+      }
+    });
+
+    const endJoy = () => {
+      touchId = null;
+      joy.x = joy.y = 0;
+      handle.style.left = '30px';
+      handle.style.top = '30px';
+    };
+
+    joystick.addEventListener('touchend', endJoy);
+    joystick.addEventListener('touchcancel', endJoy);
+
+    // ===== 월드 생성 (Perlin Noise) =====
+    const blockGeo = new THREE.BoxGeometry(1,1,1);
+    const blockMat = new THREE.MeshLambertMaterial({ color: 0x8B4513 });
+    const blocks = {};
+    const blocksGroup = new THREE.Group();
+    scene.add(blocksGroup);
+    const simplex = new SimplexNoise();
+    const worldSize = 20;
+
+    for (let x = -worldSize; x <= worldSize; x++) {
+      for (let z = -worldSize; z <= worldSize; z++) {
+        const height = Math.floor((simplex.noise2D(x/10, z/10) + 1) * 3);
+        for (let y = -1; y < height; y++) {
+          const block = new THREE.Mesh(blockGeo, blockMat);
+          block.position.set(x, y, z);
+          const key = `${x},${y},${z}`;
+          block.userData.key = key;
+          blocks[key] = block;
+          blocksGroup.add(block);
+        }
+      }
+    }
+
+    // ===== 플레이어 물리 =====
+    let velocity = new THREE.Vector3();
+    const clock = new THREE.Clock();
+    let canJump = false;
+    const gravity = 9.8;
+
+    function hasBlock(x,y,z){
+      return blocks[`${Math.floor(x)},${Math.floor(y)},${Math.floor(z)}`];
+    }
+
+    function animate(){
+      requestAnimationFrame(animate);
+      const delta = clock.getDelta();
+
+      velocity.y -= gravity * delta;
+
+      let forward = move.forward - move.backward + joy.y;
+      let strafe = move.right - move.left + joy.x;
+      const speed = 5;
+      const vx = -strafe * speed * delta;
+      const vz = -forward * speed * delta;
+
+      const pos = player.position;
+      if (!hasBlock(pos.x + vx, pos.y, pos.z) && !hasBlock(pos.x + vx, pos.y - 1.8, pos.z)) pos.x += vx;
+      if (!hasBlock(pos.x, pos.y, pos.z + vz) && !hasBlock(pos.x, pos.y - 1.8, pos.z + vz)) pos.z += vz;
+
+      pos.y += velocity.y * delta;
+      if (hasBlock(pos.x, pos.y - 1.8, pos.z)) {
+        pos.y = Math.floor(pos.y - 1.8) + 1 + 1.8;
+        velocity.y = 0;
+        canJump = true;
+      } else {
+        canJump = false;
+      }
+
+      renderer.render(scene, camera);
+    }
+    animate();
+
+    // ===== 블록 파괴 및 설치 =====
+    const raycaster = new THREE.Raycaster();
+    const pointer = new THREE.Vector2();
+
+    function breakBlock(){
+      raycaster.setFromCamera(pointer, camera);
+      const intersects = raycaster.intersectObjects(blocksGroup.children);
+      if(intersects.length){
+        const obj = intersects[0].object;
+        blocksGroup.remove(obj);
+        delete blocks[obj.userData.key];
+      }
+    }
+    function placeBlock(){
+      raycaster.setFromCamera(pointer, camera);
+      const intersects = raycaster.intersectObjects(blocksGroup.children);
+      if(intersects.length){
+        const hit = intersects[0];
+        const pos = hit.object.position.clone().add(hit.face.normal);
+        const key = `${pos.x},${pos.y},${pos.z}`;
+        if(!blocks[key]){
+          const block = new THREE.Mesh(blockGeo, blockMat);
+          block.position.copy(pos);
+          block.userData.key = key;
+          blocks[key] = block;
+          blocksGroup.add(block);
+        }
+      }
+    }
+    window.addEventListener('mousedown', e => {
+      if(e.button === 0) breakBlock();
+      if(e.button === 2) placeBlock();
+    });
+    window.addEventListener('contextmenu', e => e.preventDefault());
+    document.getElementById('breakBtn').addEventListener('touchstart', breakBlock);
+    document.getElementById('placeBtn').addEventListener('touchstart', placeBlock);
+
+    // ===== 화면 크기 조정 =====
+    window.addEventListener('resize', () => {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Perlin noise world generation, block placement and destruction
- add player gravity, collisions, and mobile controls

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689200c09eac83269a4a962da39d4cda